### PR TITLE
Fixes for XML errors on startup

### DIFF
--- a/Defs/ThingDefs_Misc/Laborers.xml
+++ b/Defs/ThingDefs_Misc/Laborers.xml
@@ -190,6 +190,8 @@
   <statBases>
     <ArmorRating_Blunt>0.35</ArmorRating_Blunt>
     <ArmorRating_Sharp>0.55</ArmorRating_Sharp>
+    <BandwidthCost>3</BandwidthCost>
+    <ControlTakingTime>18</ControlTakingTime>
   </statBases>
   <race>
       <thinkTreeMain>Gha_Laborer</thinkTreeMain>
@@ -223,10 +225,6 @@
       </li>
     </detritusLeavings>
   </race>
-  <statBases>
-    <BandwidthCost>3</BandwidthCost>
-    <ControlTakingTime>18</ControlTakingTime>
-  </statBases>
   <comps>
 	<li Class="RoboticServitude.CompProperties_GlitchVolatility">
 		<mentalBreakRatePerDay>1</mentalBreakRatePerDay>
@@ -286,6 +284,8 @@
     <MoveSpeed>5.8</MoveSpeed>
     <ArmorRating_Blunt>0.55</ArmorRating_Blunt>
     <ArmorRating_Sharp>0.45</ArmorRating_Sharp>
+    <BandwidthCost>4</BandwidthCost>
+    <ControlTakingTime>18</ControlTakingTime>
   </statBases>
   <race>
       <thinkTreeMain>Gha_Laborer</thinkTreeMain>
@@ -319,10 +319,6 @@
       </li>
     </detritusLeavings>
   </race>
-  <statBases>
-    <BandwidthCost>4</BandwidthCost>
-    <ControlTakingTime>18</ControlTakingTime>
-  </statBases>
   <comps>
 	<li Class="RoboticServitude.CompProperties_GlitchVolatility">
 		<mentalBreakRatePerDay>1</mentalBreakRatePerDay>

--- a/Defs/ThingDefs_Misc/Laborers.xml
+++ b/Defs/ThingDefs_Misc/Laborers.xml
@@ -246,6 +246,7 @@
   <label>Combat Laborer</label>
   <race>Gha_Combat_Laborer</race>
   <combatPower>150</combatPower>
+  <weaponTags></weaponTags>
   <lifeStages>
     <li>
       <bodyGraphicData>
@@ -340,6 +341,7 @@
   <label>Assassin Laborer</label>
   <race>Gha_Assassin_Laborer</race>
   <combatPower>300</combatPower>
+  <weaponTags></weaponTags>
   <lifeStages>
     <li>
       <bodyGraphicData>


### PR DESCRIPTION
I've made some changes to the Laborers.xml to fix the xml errors on startup.

Quick notes/changes:

- Added weapon tags to fix the Null Reference
- Merged the duplicate statBase 